### PR TITLE
✨ feat: add auth guard and token refresh logic

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,1 +1,161 @@
+import { getToken } from 'next-auth/jwt';
+import { NextRequest, NextResponse } from 'next/server';
+
 // 미들웨어
+const protectedRoutes = ['/character', '/community', '/live', '/shop', '/user'];
+
+const openRoutes = ['/', '/login'];
+
+// 엑세스 토큰 검증
+async function verifyAccessToken(
+  accessToken: string,
+  _id: number,
+): Promise<boolean> {
+  try {
+    const response = await fetch(
+      `https://fesp-api.koyeb.app/market/user/${_id}`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+          'Client-Id': 'febc13-final01-emjf',
+        },
+      },
+    );
+
+    return response.ok;
+  } catch (error) {
+    console.log('accessToken 검증 실패', error);
+  }
+  return false;
+}
+
+// 리프레시로 엑세스 재발급
+async function refreshAccessToken(
+  refreshToken: string,
+): Promise<string | null> {
+  try {
+    const response = await fetch(
+      'https://fesp-api.koyeb.app/market/auth/refresh',
+      {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${refreshToken}`,
+          'Client-Id': 'febc13-final01-emjf',
+        },
+      },
+    );
+
+    if (response.ok) {
+      const data = await response.json();
+      console.log('accessToken 재발급 성공');
+      return data.accessToken;
+    }
+  } catch (error) {
+    console.log('accessToken 재발급 오류', error);
+  }
+  return null;
+}
+
+// JWT 토큰 업데이트
+import type { JWT } from 'next-auth/jwt';
+
+async function updateJwtToken(
+  existingToken: JWT,
+  newAccessToken: string,
+): Promise<string> {
+  const { encode } = await import('next-auth/jwt');
+
+  const updatedToken = {
+    ...existingToken,
+    accessToken: newAccessToken,
+  };
+
+  return await encode({
+    token: updatedToken,
+    secret: process.env.NEXTAUTH_SECRET!,
+  });
+}
+
+// 비로그인자 접근 차단
+export async function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  // 차단 경로
+  if (pathname.startsWith('/api/') || pathname.startsWith('/_next/')) {
+    return NextResponse.next();
+  }
+  // 공개 경로
+  if (openRoutes.includes(pathname)) {
+    return NextResponse.next();
+  }
+
+  const isProtectedRoute = protectedRoutes.some(route =>
+    pathname.startsWith(route),
+  );
+  if (isProtectedRoute) {
+    const token = await getToken({
+      req: request,
+      secret: process.env.NEXTAUTH_SECRET,
+    });
+    // 토큰 없는 경우 (비로그인)
+    if (!token) {
+      const loginUrl = new URL('/login', request.url);
+      return NextResponse.redirect(loginUrl);
+    }
+
+    // 토큰 있는 경우
+    if (token.accessToken && token._id) {
+      const isValidToken = await verifyAccessToken(
+        token.accessToken,
+        token._id as number,
+      );
+      // 재발급 시도
+      if (!isValidToken) {
+        const refreshToken = request.cookies.get('refresh-token')?.value;
+        // 리프레시 토큰 확인
+        if (refreshToken) {
+          const newAccessToken = await refreshAccessToken(refreshToken);
+          // 새로운 엑세스 토큰 발급
+          if (newAccessToken) {
+            try {
+              const updatedJwtToken = await updateJwtToken(
+                token,
+                newAccessToken,
+              );
+              const response = NextResponse.next();
+
+              response.cookies.set('next-auth.session-token', updatedJwtToken, {
+                httpOnly: true,
+                secure: process.env.NODE_ENV === 'production',
+                sameSite: 'lax',
+                maxAge: 60 * 60 * 24 * 30, // 30일
+                path: '/',
+              });
+              return response;
+            } catch (error) {
+              console.log('JWT 갱신 실패:', error);
+              const loginUrl = new URL('/login', request.url);
+              return NextResponse.redirect(loginUrl);
+            }
+          } else {
+            console.log('accessToken 재발급 실패');
+            const loginUrl = new URL('/login', request.url);
+            return NextResponse.redirect(loginUrl);
+          }
+        } else {
+          console.log('RefreshToken 없음');
+          const loginUrl = new URL('/login', request.url);
+          return NextResponse.redirect(loginUrl);
+        }
+      }
+    } else {
+      console.log('기존 accessToken 또는 사용자 id 없음');
+      const loginUrl = new URL('/login', request.url);
+      return NextResponse.redirect(loginUrl);
+    }
+  }
+
+  return NextResponse.next();
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,11 @@
 'use client';
 
-import AuthContext from '@/context/AuthContext';
+// import AuthContext from '@/context/AuthContext';
 import '@/styles/globals.css';
 import localFont from 'next/font/local';
 import { MobileFrame } from '@/components/layout/moblie-frame/MobileFrame';
+import { SessionProvider } from 'next-auth/react';
+import TokenSync from '@/components/features/auth/TokenSync';
 
 const pretendard = localFont({
   src: '../../public/fonts/PretendardVariable.woff2',
@@ -20,7 +22,10 @@ export default function RootLayout({
   return (
     <html lang="ko" className={`${pretendard.variable}`}>
       <body className={`${pretendard.className}`}>
-        <MobileFrame>{children}</MobileFrame>
+        <SessionProvider>
+          <TokenSync />
+          <MobileFrame>{children}</MobileFrame>
+        </SessionProvider>
       </body>
     </html>
   );

--- a/src/components/features/auth/TokenSync.tsx
+++ b/src/components/features/auth/TokenSync.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { useSession } from 'next-auth/react';
+import { useAuthStore } from '@/store/auth.store';
+import { useEffect } from 'react';
+
+export default function TokenSync() {
+  const { data: session, status } = useSession();
+  const { setAccessToken, setLoginType, setUser, clearAuth } = useAuthStore();
+
+  useEffect(() => {
+    if (status === 'loading') return;
+
+    if (session?.accessToken) {
+      setAccessToken(session.accessToken);
+
+      if (session.loginType) {
+        setLoginType(session.loginType);
+      }
+
+      if (session.user) {
+        setUser({
+          _id: session.user._id,
+          name: session.user.name,
+          email: session.user.email,
+        });
+      }
+    } else {
+      clearAuth();
+    }
+  }, [session, status, setAccessToken, setLoginType, setUser, clearAuth]);
+
+  return null;
+}

--- a/src/store/auth.store.ts
+++ b/src/store/auth.store.ts
@@ -1,0 +1,40 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface AuthState {
+  accessToken: string | null;
+  loginType: string | null;
+  user: {
+    _id?: number;
+    name?: string;
+    email?: string;
+  } | null;
+
+  // action 설정
+  setAccessToken: (accessToken: string) => void;
+  setLoginType: (loginType: string) => void;
+  setUser: (user: { _id?: number; name?: string; email?: string }) => void;
+  clearAuth: () => void;
+}
+
+// store 생성
+export const useAuthStore = create<AuthState>()(
+  persist(
+    set => ({
+      accessToken: null,
+      loginType: null,
+      user: null,
+
+      setAccessToken: accessToken => set({ accessToken }),
+
+      setLoginType: loginType => set({ loginType }),
+
+      setUser: user => set({ user }),
+
+      clearAuth: () => set({ accessToken: null, loginType: null, user: null }),
+    }),
+    {
+      name: 'userInfo-storage', // localStorage
+    },
+  ),
+);


### PR DESCRIPTION
## PR 유형
- [X] 비로그인자 접근 페이지접근 차단 및 리프레쉬 토큰으로 액세스토큰 재발급(middleware.ts)

## PR 체크리스트
- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세
1. Zustand Store (auth.store.ts)

- AccessToken, 사용자 정보: localStorage에 저장
- RefreshToken: HttpOnly 쿠키에만 저장 (보안 이슈)
- 상태 관리: `setAccessToken`, `setUser`, `setLoginType`, `clearAuth`

2. Middleware (middleware.ts)

- 액세스 토큰 검증 (API 서버와 통신)
- 리프레시 토큰으로 액세스 토큰 재발급
- 재발급 받은 액세토큰을 NextAuth JWT에 저장
- 비로그인자 보호된 경로 접근 차단

3. NextAuth 설정 (route.ts)

- RefreshToken은 HttpOnly 쿠키로 관리

4. TokenSync 컴포넌트

- NextAuth 세션↔ Zustand 자동 동기화
- Layout.tsx에 `<TokenSync />`로 추가
- 모든 페이지에서 `useAuthStore()`로 손쉽게 사용 가능

## 이슈
resolves #50 
