### PR TITLE
✨ feat: implement reply CRUD functionality for community posts

### DIFF
--- a/src/app/api/comments/route.ts
+++ b/src/app/api/comments/route.ts
@@ -1,0 +1,64 @@
+// 댓글 등록, 수정, 삭제 기능
+
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(request: NextRequest) {
+  try {
+    const { _id, content } = await request.json();
+    const response = await fetch(
+      `https://fesp-api.koyeb.app/market/posts/${_id}/replies`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Client-Id': 'febc13-final01-emjf',
+        },
+        body: JSON.stringify({ _id, content }),
+      },
+    );
+    return NextResponse.json(await response.json());
+  } catch (error) {
+    console.log('댓글 등록 실패', error);
+  }
+}
+
+export async function PUT(request: NextRequest) {
+  try {
+    const { _id, reply_id, content } = await request.json();
+    const response = await fetch(
+      `https://fesp-api.koyeb.app/market/posts/${_id}/replies/${reply_id}`,
+      {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          'Client-Id': 'febc13-final01-emjf',
+        },
+        body: JSON.stringify({ content }),
+      },
+    );
+    return NextResponse.json(await response.json());
+  } catch (error) {
+    console.log('댓글 수정 실패', error);
+  }
+}
+
+export async function DELETE(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const _id = searchParams.get('_id');
+    const reply_id = searchParams.get('reply_id');
+
+    const response = await fetch(
+      `https://fesp-api.koyeb.app/market/posts/${_id}/replies/${reply_id}`,
+      {
+        method: 'DELETE',
+        headers: {
+          'Client-Id': 'febc13-final01-emjf',
+        },
+      },
+    );
+    return NextResponse.json(await response.json());
+  } catch (error) {
+    console.log('댓글 삭제 실패', error);
+  }
+}

--- a/src/app/community/[id]/layout.tsx
+++ b/src/app/community/[id]/layout.tsx
@@ -1,0 +1,15 @@
+import Script from 'next/script';
+
+export function CommunityInfoPage({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <Script
+        src="https://t1.kakaocdn.net/kakao_js_sdk/2.7.2/kakao.min.js"
+        strategy="beforeInteractive"
+      />
+      {children}
+    </>
+  );
+}
+
+export default CommunityInfoPage;

--- a/src/app/community/[id]/page.tsx
+++ b/src/app/community/[id]/page.tsx
@@ -1,5 +1,3 @@
-import CommentItem from '@/components/features/community/community-detail/CommentItem';
-import CommentInput from '@/components/features/community/community-detail/CommentInput';
 import BookmarkFeedCard from '@/components/features/community/community-bookmark/BookmarkFeedCard';
 import CommunityHeader from '@/components/features/community/community-common/CommunityHeader';
 
@@ -16,61 +14,13 @@ export default function FeedDetailPage() {
       <div className="scrollbar-hide flex-1 overflow-y-auto">
         {/* 피드 내용 */}
         <BookmarkFeedCard
-          userName="닉네임"
-          timeAgo="2시간 전"
-          description="드디어 완성된 우리집 인테리어 화분 배치하느라 힘들었지만 만족스러워요"
-          image="/images/inhwan/barrier.webp"
+          postId={1}
           profileImage="/images/inhwan/profile-default.png"
+          userName="사용자"
+          timeAgo="방금 전"
+          description="게시글 내용"
+          image="/images/inhwan/barrier.webp"
         />
-
-        {/* 댓글 목록 부분 */}
-        <div className="w-full">
-          {/* 댓글 타이틀 */}
-          <div className="mt-2.5 px-5">
-            <span className="text-sm font-bold text-black">댓글</span>
-          </div>
-
-          {/* 댓글 목록 */}
-          <div className="pb-[74px]">
-            {' '}
-            {/* 댓글 입력창 높이만큼 패딩 */}
-            <CommentItem
-              profileImage="/images/inhwan/profile-default.png"
-              userName="댓글 작성자"
-              timeAgo="1시간 전"
-              comment="정말 날씨가 좋네요 저도 싸우러 갈게요!"
-            />
-            <CommentItem
-              profileImage="/images/inhwan/profile-default.png"
-              userName="댓글 작성자"
-              timeAgo="1시간 전"
-              comment="정말 날씨가 좋네요 저도 싸우러 갈게요!"
-            />
-            <CommentItem
-              profileImage="/images/inhwan/profile-default.png"
-              userName="댓글 작성자"
-              timeAgo="1시간 전"
-              comment="정말 날씨가 좋네요 저도 싸우러 갈게요!"
-            />
-            <CommentItem
-              profileImage="/images/inhwan/profile-default.png"
-              userName="댓글 작성자"
-              timeAgo="1시간 전"
-              comment="정말 날씨가 좋네요 저도 싸우러 갈게요!"
-            />
-            <CommentItem
-              profileImage="/images/inhwan/profile-default.png"
-              userName="댓글 작성자"
-              timeAgo="1시간 전"
-              comment="정말 날씨가 좋네요 저도 싸우러 갈게요!"
-            />
-          </div>
-        </div>
-      </div>
-
-      {/* 댓글 입력창 - 화면 맨 밑에 고정 */}
-      <div className="sticky bottom-0 z-10 bg-white">
-        <CommentInput profileImage="/images/inhwan/profile-default.png" />
       </div>
     </div>
   );

--- a/src/app/community/page.tsx
+++ b/src/app/community/page.tsx
@@ -14,6 +14,7 @@ export default function CommunityPage() {
       <div className="scrollbar-hide flex-1 overflow-y-auto">
         {/* 피드 아이템 */}
         <CommunityMain
+          id={1}
           userName="닉네임"
           timeAgo="2시간 전"
           description="드디어 완성된 결계 마왕의 졸개를 처리하느라 ..."
@@ -22,6 +23,7 @@ export default function CommunityPage() {
         />
 
         <CommunityMain
+          id={2}
           userName="닉네임"
           timeAgo="2시간 전"
           description="드디어 완성된 결계 마왕의 졸개를 처리하느라 ..."
@@ -30,6 +32,7 @@ export default function CommunityPage() {
         />
 
         <CommunityMain
+          id={3}
           userName="닉네임"
           timeAgo="2시간 전"
           description="드디어 완성된 결계 마왕의 졸개를 처리하느라 ..."

--- a/src/components/features/community/community-bookmark/BookmarkFeedCard.tsx
+++ b/src/components/features/community/community-bookmark/BookmarkFeedCard.tsx
@@ -44,9 +44,11 @@ interface BookmarkFeedCardProps {
   timeAgo: string;
   image: string;
   description: string;
+  postId: number;
 }
 
 export default function BookmarkFeedCard({
+  postId,
   userName = '오다구',
   timeAgo = '2시간 전',
   description = '드디어 완성된 결계 마왕의 졸개를 처리하느라 힘들었지만 만족스럽다고 말하고 싶다',
@@ -95,9 +97,7 @@ export default function BookmarkFeedCard({
   };
 
   const handleShare = () => {
-    if (navigator.clipboard) {
-      handleShareToKakao();
-    }
+    handleShareToKakao();
   };
 
   const handleCheckBookmark = () => {
@@ -174,7 +174,7 @@ export default function BookmarkFeedCard({
       {/* 댓글 영역 */}
       {isOpenComment && (
         <div className="border-b border-[#EAEAEA] px-5 py-4">
-          <CommentSection />
+          <CommentSection postId={postId} />
         </div>
       )}
     </div>

--- a/src/components/features/community/community-common/CommunityHeader.tsx
+++ b/src/components/features/community/community-common/CommunityHeader.tsx
@@ -1,4 +1,5 @@
 import { ChevronLeft } from 'lucide-react';
+import Link from 'next/link';
 
 // 허용되는 title들만 지정하게 함
 type HeaderTitle = '피드등록' | '북마크' | '피드보기';
@@ -11,9 +12,9 @@ export default function CommunityHeader({ title }: CommunityHeaderProps) {
   return (
     <div className="relative flex h-[38px] w-full items-center justify-center px-5">
       {/* 왼쪽 - 뒤로가기 아이콘 */}
-      <div className="absolute left-5">
+      <Link href="/community" className="absolute left-5">
         <ChevronLeft size={24} />
-      </div>
+      </Link>
 
       {/* 가운데 - 타이틀 텍스트 */}
       <div>

--- a/src/components/features/community/community-create/FeedSubmitButton.tsx
+++ b/src/components/features/community/community-create/FeedSubmitButton.tsx
@@ -1,14 +1,17 @@
 interface FeedSubmitButtonProps {
   text?: string;
   variant?: 'submitBtn' | 'CommentCancel';
+  onClick: () => void;
 }
 
 export default function FeedSubmitButton({
   text = '작성완료',
   variant = 'submitBtn',
+  onClick,
 }: FeedSubmitButtonProps) {
   return (
     <button
+      onClick={onClick}
       className={`h-14 w-[350px] rounded-lg text-xl font-bold ${
         variant === 'submitBtn'
           ? 'bg-[#FE508B] text-white' // 핑크 배경, 흰색 텍스트

--- a/src/components/features/community/community-detail/CommentInput.tsx
+++ b/src/components/features/community/community-detail/CommentInput.tsx
@@ -1,13 +1,75 @@
+'use client';
+
 import Image from 'next/image';
 import { CircleArrowUp } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
 
 interface CommentInputProps {
   profileImage: string;
+  postId: number;
+  onCommentAdd: () => void;
+  mode: 'create' | 'edit';
+  initialValue?: string;
+  replyId?: string;
+  onEditSubmit: () => void;
 }
 
 export default function CommentInput({
   profileImage = '/images/inhwan/profile-default.png',
+  postId,
+  onCommentAdd,
+  mode = 'create',
+  initialValue = '',
+  replyId,
+  onEditSubmit,
 }: CommentInputProps) {
+  const [content, setContent] = useState('');
+  const router = useRouter();
+
+  useEffect(() => {
+    setContent(initialValue);
+  }, [initialValue]);
+
+  // 댓글 작성 및 수정 까지
+  const handleSubmit = async () => {
+    try {
+      if (mode === 'edit' && replyId) {
+        const response = await fetch('/api/comments', {
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ _id: postId, reply_id: replyId, content }),
+        });
+        if (response.ok) {
+          setContent('');
+          onEditSubmit?.();
+        }
+      } else {
+        const response = await fetch('/api/comments', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            _id: postId,
+            content,
+          }),
+        });
+        if (response.ok) {
+          setContent('');
+          router.refresh();
+          onCommentAdd?.();
+        } else {
+          throw new Error('댓글 등록 실패');
+        }
+      }
+    } catch (error) {
+      console.log('댓글 등록 오류', error);
+    }
+  };
+
   return (
     <div className="flex h-[74px] w-full items-center gap-3 bg-white px-5">
       {/* 프로필 이미지 */}
@@ -27,9 +89,11 @@ export default function CommentInput({
           type="text"
           placeholder="댓글을 입력하세요"
           className="h-10 w-full rounded-full bg-[#F3F4F6] px-4 text-sm placeholder-[#c3c3c3] focus:outline-none"
+          value={content}
+          onChange={e => setContent(e.target.value)}
         />
       </div>
-      <button className="absolute right-2">
+      <button onClick={handleSubmit}>
         <CircleArrowUp size={24} className="mr-4" />
       </button>
     </div>

--- a/src/components/features/community/community-detail/CommentItem.tsx
+++ b/src/components/features/community/community-detail/CommentItem.tsx
@@ -1,6 +1,8 @@
+'use client';
+
 import Image from 'next/image';
 import { EllipsisVertical } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import CommentOptionsModal from './CommentOptionsModal';
 
 interface CommentItemProps {
@@ -8,6 +10,10 @@ interface CommentItemProps {
   userName: string;
   timeAgo: string;
   comment: string;
+  postId: number;
+  replyId: string;
+  onEditClick: (replyId: string, content: string) => void;
+  onAfterDelete: () => void;
 }
 
 export default function CommentItem({
@@ -15,29 +21,39 @@ export default function CommentItem({
   timeAgo = '1시간 전',
   comment = '정말 날씨가 좋네요 저도 싸우러 갈게요!',
   profileImage = '/images/inhwan/profile-default.png',
+  postId,
+  replyId,
+  onEditClick,
+  onAfterDelete,
 }: CommentItemProps) {
   const [isOptionModal, setIsOptionModal] = useState(false);
+
   const modalRef = useRef<HTMLDivElement>(null);
 
   const handleCommentOption = () => {
     setIsOptionModal(!isOptionModal);
   };
 
-  // 빈 화면 클릭 시 해제
-  useEffect(() => {
-    const handleClickOutside = (e: PointerEvent) => {
-      if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
-        setIsOptionModal(false);
-      }
-    };
-    if (isOptionModal) {
-      document.addEventListener('pointerdown', handleClickOutside);
-    }
+  const closeModal = () => setIsOptionModal(false);
 
-    return () => {
-      document.removeEventListener('pointerdown', handleClickOutside);
-    };
-  }, [isOptionModal]);
+  const handleEdit = () => {
+    onEditClick(replyId, comment);
+    setIsOptionModal(false);
+  };
+
+  const handleDelete = async () => {
+    try {
+      await fetch('/api/comments', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ _id: postId, reply_id: replyId }),
+      });
+      onAfterDelete();
+    } catch (error) {
+      console.log('댓글 삭제 실패', error);
+    }
+    setIsOptionModal(false);
+  };
 
   return (
     <div className="w-full">
@@ -81,10 +97,16 @@ export default function CommentItem({
             className="relative bottom-3 flex-shrink-0"
             onClick={handleCommentOption}
           >
-            <EllipsisVertical size={18} className="text-black" />
+            <EllipsisVertical size={18} />
           </button>
         </div>
-        {isOptionModal && <CommentOptionsModal />}
+        {isOptionModal && (
+          <CommentOptionsModal
+            onClose={closeModal}
+            onEdit={handleEdit}
+            onDelete={handleDelete}
+          />
+        )}
       </div>
 
       {/* 하단 보더 (1px) */}

--- a/src/components/features/community/community-detail/CommentOptionsModal.tsx
+++ b/src/components/features/community/community-detail/CommentOptionsModal.tsx
@@ -1,17 +1,36 @@
 import FeedSubmitButton from '../community-create/FeedSubmitButton';
 
-export default function CommentOptionsModal() {
+interface CommentOptionsModalProps {
+  onClose: () => void;
+  onEdit: () => void;
+  onDelete: () => void;
+}
+
+export default function CommentOptionsModal({
+  onClose,
+  onEdit,
+  onDelete,
+}: CommentOptionsModalProps) {
+  const handleCancel = () => {
+    onClose();
+  };
   return (
     <div className="fixed inset-0 z-50 flex items-end justify-center">
       {/* Dim 처리 */}
-      <div className="bg-opacity-50 absolute inset-0 bg-black"></div>
+      <div
+        className="absolute inset-0"
+        style={{ backgroundColor: 'rgba(0, 0, 0, 0.3)' }}
+      ></div>
 
       {/* 모달 내용 */}
       <div className="relative z-10 px-5 pb-8">
         {/* 상단 옵션 박스 (350x112) */}
         <div className="mb-[30px] flex h-[112px] w-[350px] flex-col rounded-lg bg-white">
           {/* 삭제하기 버튼 */}
-          <button className="flex flex-1 items-center justify-center">
+          <button
+            className="flex flex-1 items-center justify-center"
+            onClick={onDelete}
+          >
             <span className="text-lg font-semibold text-[#FE508B]">
               삭제하기
             </span>
@@ -21,13 +40,20 @@ export default function CommentOptionsModal() {
           <div className="border-b border-[#EAEAEA]"></div>
 
           {/* 수정하기 버튼 */}
-          <button className="flex flex-1 items-center justify-center">
+          <button
+            className="flex flex-1 items-center justify-center"
+            onClick={onEdit}
+          >
             <span className="text-lg font-semibold text-black">수정하기</span>
           </button>
         </div>
 
         {/* 하단 취소 버튼 */}
-        <FeedSubmitButton text="취소" variant="CommentCancel" />
+        <FeedSubmitButton
+          text="취소"
+          variant="CommentCancel"
+          onClick={handleCancel}
+        />
       </div>
     </div>
   );

--- a/src/components/features/community/community-detail/CommentSection.tsx
+++ b/src/components/features/community/community-detail/CommentSection.tsx
@@ -1,40 +1,101 @@
+'use client';
+
 import CommentItem from './CommentItem';
 import CommentInput from './CommentInput';
+import { useEffect, useState } from 'react';
+import { fetchComments } from '@/data/functions/CommentsFetch';
 
-export default function CommentSection() {
+type Comment = {
+  _id: string;
+  user?: {
+    profileImage?: string;
+    name?: string;
+  };
+  createdAt?: string;
+  content?: string;
+};
+
+export default function CommentSection({ postId }: { postId: number }) {
+  const [comments, setComments] = useState<Comment[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isEdit, setIsEdit] = useState<null | {
+    replyId: string;
+    content: string;
+  }>(null);
+
+  // input으로 수정할 수 있게끔 전달
+  const handleEditClick = (replyId: string, content: string) => {
+    setIsEdit({ replyId, content });
+  };
+
+  // 수정 완료 후 다시 등록
+  const handleEditSubmit = () => {
+    setIsEdit(null);
+    getComments();
+  };
+
+  // 댓글 목록 불러옴
+  const getComments = async () => {
+    try {
+      setIsLoading(true);
+      const data = await fetchComments(postId);
+      setComments(data.items || []);
+    } catch (error) {
+      console.log('댓글 목록 조회 오류', error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // postId 바뀔 때 마다 geComments 호출
+  useEffect(() => {
+    if (postId) getComments();
+  }, [postId]);
+
   return (
     <div className="w-full">
       {/* 댓글 타이틀 */}
-      <div className="px-5 mt-2.5">
-        <span className="text-sm text-black font-bold">댓글</span>
+      <div className="mt-2.5 px-5">
+        <span className="text-sm font-bold text-black">댓글</span>
       </div>
 
       {/* 댓글 목록 */}
       <div>
-        <CommentItem
-          profileImage="/images/inhwan/profile-default.png"
-          userName="댓글 작성자"
-          timeAgo="1시간 전"
-          comment="정말 날씨가 좋네요 저도 싸우러 갈게요!"
-        />
-
-        <CommentItem
-          profileImage="/images/inhwan/profile-default.png"
-          userName="댓글 작성자"
-          timeAgo="1시간 전"
-          comment="정말 날씨가 좋네요 저도 싸우러 갈게요!"
-        />
-
-        <CommentItem
-          profileImage="/images/inhwan/profile-default.png"
-          userName="댓글 작성자"
-          timeAgo="1시간 전"
-          comment="정말 날씨가 좋네요 저도 싸우러 갈게요!"
-        />
+        {isLoading ? (
+          <div className="p-5 text-center text-gray-500">
+            댓글을 불러오는 중...
+          </div>
+        ) : comments.length > 0 ? (
+          comments.map(comment => (
+            <CommentItem
+              key={comment._id}
+              profileImage={comment.user?.profileImage || ''}
+              userName={comment.user?.name || '사용자'}
+              timeAgo={comment.createdAt || ''}
+              comment={comment.content || ''}
+              postId={postId}
+              replyId={comment._id}
+              onEditClick={handleEditClick}
+              onAfterDelete={getComments}
+            />
+          ))
+        ) : (
+          <div className="p-5 text-center text-gray-500">
+            아직 댓글이 없습니다.
+          </div>
+        )}
       </div>
 
       {/* 댓글 입력창 */}
-      <CommentInput profileImage="/images/inhwan/profile-default.png" />
+      <CommentInput
+        postId={postId}
+        onCommentAdd={() => getComments()}
+        profileImage="/images/inhwan/profile-default.png"
+        mode={isEdit ? 'edit' : 'create'}
+        replyId={isEdit?.replyId}
+        initialValue={isEdit?.content || ''}
+        onEditSubmit={handleEditSubmit}
+      />
     </div>
   );
 }

--- a/src/components/features/community/community-main/CommunityMain.tsx
+++ b/src/components/features/community/community-main/CommunityMain.tsx
@@ -1,7 +1,9 @@
 import Image from 'next/image';
 import { ChevronRight } from 'lucide-react';
+import Link from 'next/link';
 
 interface CommunityMainProps {
+  id: number;
   profileImage: string;
   userName: string;
   timeAgo: string;
@@ -10,6 +12,7 @@ interface CommunityMainProps {
 }
 
 export default function CommunityMain({
+  id,
   userName = '오다구',
   timeAgo = '2시간 전',
   description = '드디어 완성된 결계 마왕의 졸개를 처리하느라 ...',
@@ -56,9 +59,9 @@ export default function CommunityMain({
         <div className="flex-1 truncate pr-2 text-sm text-black">
           {description}
         </div>
-        <div className="text-black">
+        <Link href={`/community/${id}`}>
           <ChevronRight size={20} />
-        </div>
+        </Link>
       </div>
     </div>
   );

--- a/src/components/features/community/community-main/CommunityMainHeader.tsx
+++ b/src/components/features/community/community-main/CommunityMainHeader.tsx
@@ -1,9 +1,10 @@
 import Image from 'next/image';
 import { Pencil } from 'lucide-react';
+import Link from 'next/link';
 
 export default function CommunityMainHeader() {
   return (
-    <div className="flex w-full items-center justify-between border-b border-[#F3F4F6] px-5 pt-5 pb-8 h-[38px]">
+    <div className="flex h-[38px] w-full items-center justify-between border-b border-[#F3F4F6] px-5 pt-5 pb-8">
       {/* 왼쪽 - 로고 */}
       <div>
         <Image
@@ -20,9 +21,9 @@ export default function CommunityMainHeader() {
       </div>
 
       {/* 오른쪽 - 편집 아이콘 */}
-      <div>
+      <Link href="/community/write">
         <Pencil size={24} />
-      </div>
+      </Link>
     </div>
   );
 }

--- a/src/data/functions/CommentsFetch.ts
+++ b/src/data/functions/CommentsFetch.ts
@@ -1,0 +1,15 @@
+// 댓글 조회
+export async function fetchComments(_id: number) {
+  try {
+    const response = await fetch(
+      `https://fesp-api.koyeb.app/market/posts/${_id}/replies`,
+      {
+        headers: { 'Client-Id': 'febc13-final01-emjf' },
+      },
+    );
+    if (!response.ok) throw new Error('댓글 조회 실패');
+    return await response.json();
+  } catch (error) {
+    console.log('댓글 조회 오류', error);
+  }
+}


### PR DESCRIPTION
## PR 유형
- [X] 커뮤니티 게시물 댓글 등록, 수정, 삭제 기능 추가

## PR 체크리스트
- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세
댓글 목록 조회

게시물별 댓글 리스트를 API에서 받아와 렌더링
- 댓글 등록

입력창에서 댓글 작성 시 POST API 호출
- 등록 후 댓글 목록 자동 갱신
- 댓글 수정

각 댓글의 옵션 중 수정하기 클릭 시, 입력창에 기존 댓글 내용 자동 입력
- 수정 모드에서 전송 시 PUT API 호출
- 수정 완료 후 목록 갱신

댓글 삭제
- 각 댓글의 옵션 중 삭제하기 클릭 시 DELETE API 호출
- 삭제 완료 후 목록 갱신

컴포넌트 코드 정리
- 댓글 옵션 모달(수정/삭제) 구현
- 등록/수정/삭제 시 입력창 및 목록 상태 자동 관리
- 불필요한 코드 및 변수 제거
- 컴포넌트별 props 구조 통일 및 최적화

## 이슈
resolves #54 
