### PR TITLE
⚡️ Feat: edit Redering this month's live products only

### DIFF
--- a/src/app/shop/ShopList.tsx
+++ b/src/app/shop/ShopList.tsx
@@ -130,13 +130,9 @@ export default function ShopList({ initialData }: { initialData: Product[] }) {
           mainImageSrc={product.mainImages[0]?.path}
           category={product.extra.category}
           discountRate={product.extra.discountRate}
-          discountPrice={product.extra.discountedPrice}
           recommendedBy={product.extra.recommendedBy}
           key={product._id}
           textPrice="text-base"
-          liveTitle={product.extra.live?.title}
-          liveRate={product.extra.live?.liveDiscountRate}
-          livePrice={product.extra.live?.livePrice}
         />,
       );
 

--- a/src/app/shop/page.tsx
+++ b/src/app/shop/page.tsx
@@ -5,6 +5,7 @@ import { ShopBanner } from '@/components/features/shop/ShopBanner';
 import { ShopLiveProducts } from '@/components/features/shop/ShopLiveProducts';
 import TabBar from '@/components/layout/tabbar/Tabbar';
 import { fetchAllProducts, fetchProducts } from '@/data/functions/ProductFetch';
+import moment from 'moment';
 import { Metadata } from 'next';
 
 export const metadata: Metadata = {
@@ -13,11 +14,18 @@ export const metadata: Metadata = {
 };
 
 export default async function ShopPage() {
+  const now = moment();
+  const isThisMonth = (dateStr?: string) => {
+    if (!dateStr) return false;
+    const date = moment(dateStr);
+    return date.month() === now.month() && date.year() === now.year();
+  };
+
   const initialData = await fetchProducts(1);
   const liveData = await fetchAllProducts();
-  const initialLiveFiltered = liveData.filter(
-    product => product.extra.isLiveSpecial,
-  );
+  const initialLiveFiltered = liveData
+    .filter(product => product.extra.isLiveSpecial)
+    .filter(product => isThisMonth(product.extra.live?.start));
 
   return (
     <>

--- a/src/components/features/shop/ShopLiveProducts.tsx
+++ b/src/components/features/shop/ShopLiveProducts.tsx
@@ -11,35 +11,43 @@ import 'swiper/swiper-bundle.css';
 
 export const ShopLiveProducts = ({ liveData }: { liveData: Product[] }) => {
   const currentLive = useLiveStore(state => state.currentLive);
-
   const now = moment();
 
-  const sortedLiveData = [...liveData].sort((a, b) => {
-    const aLive = currentLive.find(
-      live => live._id === a._id && now.isBetween(live.start, live.end),
-    );
-    const bLive = currentLive.find(
-      live => live._id === b._id && now.isBetween(live.start, live.end),
-    );
+  const getLiveRank = (product: Product) => {
+    const start = moment(product.extra.live?.start);
+    const end = moment(product.extra.live?.end);
 
-    if (aLive && !bLive) return -1;
-    if (!aLive && bLive) return 1;
-    return 0;
-  });
+    if (now.isBetween(start, end)) return 0; // 라이브 중
+    if (now.isBefore(start)) return 1; // 라이브 예정
+    return 2; // 라이브 끝
+  };
+
+  const sortedLiveData = [...liveData].sort(
+    (a, b) => getLiveRank(a) - getLiveRank(b),
+  );
 
   const liveProducts = sortedLiveData.map(product => {
     const liveInfo = currentLive.find(live => live._id === product._id);
-
     const isLiveNow = liveInfo && now.isBetween(liveInfo.start, liveInfo.end);
-
     const isEnded = now.isAfter(product.extra.live?.end);
+
+    const matchedLive = liveData.find(live => live._id === product._id);
+    const start = moment(matchedLive?.extra?.live?.start);
 
     return (
       <SwiperSlide key={product._id} className="mr-2.5 !w-[calc(100%/3.5)]">
         {!isLiveNow && (
           <div className="absolute z-2 flex aspect-square w-full rounded-2xl bg-black/50 text-white">
-            <p className="absolute top-1/2 h-fit w-full -translate-y-1/2 text-center text-sm">
-              {isEnded ? '종료된 라이브' : '라이브 예정'}
+            <p className="absolute top-1/2 h-fit w-full -translate-y-1/2 text-center text-xs md:text-sm">
+              {isEnded ? (
+                '종료된 라이브'
+              ) : (
+                <>
+                  {start.format('MM월 DD일')} <br />
+                  {start.format('HH시')} <br />
+                  라이브 예정
+                </>
+              )}
             </p>
           </div>
         )}

--- a/src/components/features/shop/ShopLiveProducts.tsx
+++ b/src/components/features/shop/ShopLiveProducts.tsx
@@ -37,7 +37,7 @@ export const ShopLiveProducts = ({ liveData }: { liveData: Product[] }) => {
     return (
       <SwiperSlide key={product._id} className="mr-2.5 !w-[calc(100%/3.5)]">
         {!isLiveNow && (
-          <div className="pointer-events-none absolute z-2 flex aspect-square w-full rounded-2xl bg-black/50 text-white">
+          <div className="absolute z-2 flex aspect-square w-full rounded-2xl bg-black/50 text-white">
             <p className="absolute top-1/2 h-fit w-full -translate-y-1/2 text-center text-sm">
               {isEnded ? '종료된 라이브' : '라이브 예정'}
             </p>
@@ -50,12 +50,8 @@ export const ShopLiveProducts = ({ liveData }: { liveData: Product[] }) => {
           mainImageSrc={product.mainImages[0]?.path}
           category={product.extra.category}
           discountRate={product.extra.discountRate}
-          discountPrice={product.extra.discountedPrice}
           recommendedBy={product.extra.recommendedBy}
           textPrice="text-sm"
-          liveTitle={product.extra?.live?.title}
-          liveRate={product.extra?.live?.liveDiscountRate}
-          livePrice={product.extra?.live?.livePrice}
         />
       </SwiperSlide>
     );

--- a/src/components/features/shop/ShopLiveProducts.tsx
+++ b/src/components/features/shop/ShopLiveProducts.tsx
@@ -66,8 +66,16 @@ export const ShopLiveProducts = ({ liveData }: { liveData: Product[] }) => {
   });
 
   return (
-    <Swiper spaceBetween={10} slidesPerView={3.5}>
-      {liveProducts}
-    </Swiper>
+    <>
+      <Swiper spaceBetween={10} slidesPerView={3.5}>
+        {liveProducts}
+      </Swiper>
+
+      {liveData.length === 0 && (
+        <p className="p-10 text-center text-[#c3c3c3]">
+          이번 달 라이브 특가 상품이 없습니다.
+        </p>
+      )}
+    </>
   );
 };

--- a/src/components/features/shop/ShopProduct.tsx
+++ b/src/components/features/shop/ShopProduct.tsx
@@ -17,12 +17,8 @@ interface ShopProductProps {
   mainImageSrc: string;
   category: string[];
   discountRate: number;
-  discountPrice: number;
   recommendedBy: string;
   textPrice: string;
-  liveTitle: string;
-  liveRate: number;
-  livePrice: number;
 }
 
 //       component: shop main 상품 컴포넌트       //
@@ -33,11 +29,7 @@ export const ShopProduct = ({
   mainImageSrc,
   discountRate,
   recommendedBy,
-  discountPrice,
   textPrice,
-  liveTitle,
-  liveRate,
-  livePrice,
 }: ShopProductProps) => {
   // 카테고리 한글 변환, 배경색, 글자색
   const recommendData: Record<
@@ -74,10 +66,7 @@ export const ShopProduct = ({
 
   //        render: 상품 렌더        //
   return (
-    <Link
-      href={isLive ? '/live' : `/shop/${_id}`}
-      className={`mb-2 flex w-full flex-col gap-1`}
-    >
+    <Link href="/live" className={`mb-2 flex w-full flex-col gap-1`}>
       {/* 라이브 중인 상품일 경우 라이브 뱃지 */}
       {isLive && (
         <div className="absolute top-2 -left-2 z-5">
@@ -113,10 +102,10 @@ export const ShopProduct = ({
       <p className={`${textPrice} font-semibold`}>
         {discountRate && (
           <span className="sale pointer-events-none mr-1 text-[#FE508B]">
-            {isLive ? liveRate : discountRate}%
+            {discountRate}%
           </span>
         )}
-        {isLive ? livePrice : discountPrice ? discountPrice : price}원
+        {price}원
       </p>
     </Link>
   );

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -32,8 +32,6 @@ export interface Product {
       title: string;
       livePath: string;
       liveId: string;
-      livePrice: number;
-      liveDiscountRate: number;
     };
   };
   options?: ProductOption[];


### PR DESCRIPTION
## PR 유형
- [x] 새로운 기능 추가

## PR 체크리스트
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세
- 쇼핑 메인 라이브 상품 렌더링 방식 변경(이번 달 상품만 렌더링되도록)
- 쇼핑 메인 상품들 라이브 price만으로 렌더링되게 변경

## 이슈
resolves #125
